### PR TITLE
Update rxlr_motifs.xml

### DIFF
--- a/tools/protein_analysis/rxlr_motifs.xml
+++ b/tools/protein_analysis/rxlr_motifs.xml
@@ -6,7 +6,7 @@
         <requirement type="package">signalp</requirement>
         <!-- Need HMMER for Whisson et al. (2007) -->
         <requirement type="binary">hmmsearch</requirement>
-        <requirement type="package">hmmsearch</requirement>
+        <requirement type="package" version="2.3.2">hmmsearch</requirement>
     </requirements>
     <stdio>
         <!-- Anything other than zero is an error -->


### PR DESCRIPTION
At least hmmer is available through conda :)


```
conda search hmmer
Fetching package metadata ...........
hmmer                        2.3.2                         0  bioconda/linux-64
                             3.1b2                         0  bioconda/linux-64
                             3.1b2                         1  bioconda/linux-64
```

PSort, under GPL licence, should have a conda package. (wolfpsort seem down)
For sure, we will have to wait a little for signalp, promoter and tmhmm because of their licence :/