### PR TITLE
Ignore empty column names

### DIFF
--- a/tools/seq_filter_by_id/README.rst
+++ b/tools/seq_filter_by_id/README.rst
@@ -89,6 +89,7 @@ v0.2.2  - Use the ``format_source=...`` tag.
 v0.2.3  - Ignore blank lines in ID file (contributed by Gildas Le Corguillé).
         - Defensive quoting of filenames etc in the command definition
           (internal change only).
+v0.2.5  - Ignore empty column names: typically R outputs
 ======= ======================================================================
 
 

--- a/tools/seq_filter_by_id/seq_filter_by_id.py
+++ b/tools/seq_filter_by_id/seq_filter_by_id.py
@@ -74,7 +74,7 @@ parser.add_option("-v", "--version", dest="version",
 options, args = parser.parse_args()
 
 if options.version:
-    print "v0.2.4"
+    print "v0.2.5"
     sys.exit(0)
 
 in_file = options.input
@@ -214,7 +214,10 @@ for tabular_file, columns in identifiers:
             if not line.strip():  # skip empty lines
                 continue
             if not line.startswith("#"):
-                file_ids.add(clean_name(line.rstrip("\n").split("\t")[col]))
+                current_id = line.rstrip("\n").split("\t")[col]
+                if current_id == "": #if for example, the column name is empty: typically R outputs
+                    continue
+                file_ids.add(clean_name(current_id))
     print "Using %i IDs from column %s in tabular file" % (len(file_ids), ", ".join(str(col + 1) for col in columns))
     if ids is None:
         ids = file_ids

--- a/tools/seq_filter_by_id/seq_filter_by_id.xml
+++ b/tools/seq_filter_by_id/seq_filter_by_id.xml
@@ -1,8 +1,7 @@
-<tool id="seq_filter_by_id" name="Filter sequences by ID" version="0.2.3">
+<tool id="seq_filter_by_id" name="Filter sequences by ID" version="0.2.5">
     <description>from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.64">biopython</requirement>
-        <requirement type="python-module">Bio</requirement>
     </requirements>
     <stdio>
         <!-- Anything other than zero is an error -->


### PR DESCRIPTION
Skip empty column names.

Here an example from one of the Trinity outputs

```
	sample1	sample2
TRINITY_DN6_c0_g1	0	0
TRINITY_DN7_c0_g1	525311.05	525311.05
TRINITY_DN0_c0_g1	0	0
TRINITY_DN5_c0_g1	329523.81	329523.81
TRINITY_DN3_c0_g1	145165.14	145165.14
TRINITY_DN4_c0_g1	0	0
TRINITY_DN8_c0_g1	0	0
```

By experience, it's the case of a lot of R outputs