### PR TITLE
Migrate seq_filter_by_id to conda

### DIFF
--- a/tools/seq_filter_by_id/seq_filter_by_id.xml
+++ b/tools/seq_filter_by_id/seq_filter_by_id.xml
@@ -1,6 +1,7 @@
 <tool id="seq_filter_by_id" name="Filter sequences by ID" version="0.2.7">
     <description>from a tabular file</description>
     <requirements>
+        <requirement type="package" version="2.7">python</requirement>
         <requirement type="package" version="1.67">biopython</requirement>
     </requirements>
     <version_command>

--- a/tools/seq_filter_by_id/tool_dependencies.xml
+++ b/tools/seq_filter_by_id/tool_dependencies.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-    <package name="biopython" version="1.67">
-        <repository name="package_biopython_1_67" owner="biopython" />
-    </package>
-</tool_dependency>

--- a/tools/seq_select_by_id/seq_select_by_id.xml
+++ b/tools/seq_select_by_id/seq_select_by_id.xml
@@ -1,6 +1,7 @@
 <tool id="seq_select_by_id" name="Select sequences by ID" version="0.0.14">
     <description>from a tabular file</description>
     <requirements>
+        <requirement type="package" version="2.7">python</requirement>
         <requirement type="package" version="1.67">biopython</requirement>
     </requirements>
     <version_command>

--- a/tools/seq_select_by_id/tool_dependencies.xml
+++ b/tools/seq_select_by_id/tool_dependencies.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-    <package name="biopython" version="1.67">
-        <repository name="package_biopython_1_67" owner="biopython" />
-    </package>
-</tool_dependency>


### PR DESCRIPTION
Hi,
Here's a little change to seq_filter_by_id to make it work properly with conda.
The biopython requirement was not sufficient as the py script fails with python 3.x