### PR TITLE
Fixing python2.7 and python3 compatibility issue

### DIFF
--- a/tools/protein_analysis/seq_analysis_utils.py
+++ b/tools/protein_analysis/seq_analysis_utils.py
@@ -107,10 +107,7 @@ def fasta_iterator(filename, max_len=None, truncate=None):
                 "Sequence %s is length %i, max length %i"
                 % (title.split()[0], len(seq), max_len)
             )
-        try:
-            yield title, seq
-        except StopIteration:
-            return
+        yield title, seq
 
 
 def split_fasta(

--- a/tools/protein_analysis/seq_analysis_utils.py
+++ b/tools/protein_analysis/seq_analysis_utils.py
@@ -107,8 +107,10 @@ def fasta_iterator(filename, max_len=None, truncate=None):
                 "Sequence %s is length %i, max length %i"
                 % (title.split()[0], len(seq), max_len)
             )
-        yield title, seq
-    raise StopIteration
+        try:
+            yield title, seq
+        except StopIteration:
+            return
 
 
 def split_fasta(


### PR DESCRIPTION
Original traceback:
```
Traceback (most recent call last):
  File "/home/nicholas.carleson@usda-ars.orst.edu/opt/pico_galaxy/tools/protein_analysis/seq_analysis_utils.py", line 111, in fasta_iterator
    raise StopIteration
StopIteration
```