### PR TITLE
Remove deprecated file open mode 'rU'

### DIFF
--- a/tools/fasta_filter_by_id/README.rst
+++ b/tools/fasta_filter_by_id/README.rst
@@ -53,6 +53,7 @@ v0.0.5  - Explicit dependency on ``galaxy_sequence_utils``.
         - Use standard MIT license (was previously using the MIT/BSD style
           Biopython Licence Agreement).
 v0.0.6  - Python 3 compatible print function.
+v0.0.7  - Fix file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/fasta_filter_by_id/fasta_filter_by_id.py
+++ b/tools/fasta_filter_by_id/fasta_filter_by_id.py
@@ -45,7 +45,7 @@ except ValueError:
 
 # Read tabular file and record all specified identifiers
 ids = set()
-handle = open(tabular_file, "rU")
+handle = open(tabular_file)
 if len(columns) > 1:
     # General case of many columns
     for line in handle:
@@ -66,7 +66,7 @@ else:
 handle.close()
 
 # Write filtered FASTA file based on IDs from tabular file
-reader = fastaReader(open(in_file, "rU"))
+reader = fastaReader(open(in_file))
 if out_positive_file != "-" and out_negative_file != "-":
     print("Generating two FASTA files")
     positive_writer = fastaWriter(open(out_positive_file, "w"))

--- a/tools/fasta_filter_by_id/fasta_filter_by_id.py
+++ b/tools/fasta_filter_by_id/fasta_filter_by_id.py
@@ -16,7 +16,7 @@ Note in the default NCBI BLAST+ tabular output, the query sequence ID is
 in column one, and the ID of the match from the database is in column two.
 Here sensible values for the column numbers would therefore be "1" or "2".
 
-This tool is copyright 2010-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2010-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See accompanying text file for licence details (MIT license).
 """
@@ -26,7 +26,7 @@ from __future__ import print_function
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.6")
+    print("v0.0.7")
     sys.exit(0)
 
 from galaxy_utils.sequence.fasta import fastaReader, fastaWriter

--- a/tools/fasta_filter_by_id/fasta_filter_by_id.xml
+++ b/tools/fasta_filter_by_id/fasta_filter_by_id.xml
@@ -1,4 +1,4 @@
-<tool id="fasta_filter_by_id" name="Filter FASTA by ID" version="0.0.6" hidden="true">
+<tool id="fasta_filter_by_id" name="Filter FASTA by ID" version="0.0.7" hidden="true">
     <description>from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tools/fastq_filter_by_id/README.rst
+++ b/tools/fastq_filter_by_id/README.rst
@@ -54,6 +54,7 @@ v0.0.5  - Explicit dependency on ``galaxy_sequence_utils``.
         - Use standard MIT license (was previously using the MIT/BSD style
           Biopython Licence Agreement).
 v0.0.6  - Python 3 compatible print function.
+v0.0.7  - Fix file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/fastq_filter_by_id/fastq_filter_by_id.py
+++ b/tools/fastq_filter_by_id/fastq_filter_by_id.py
@@ -16,7 +16,7 @@ Note in the default NCBI BLAST+ tabular output, the query sequence ID is
 in column one, and the ID of the match from the database is in column two.
 Here sensible values for the column numbers would therefore be "1" or "2".
 
-This tool is copyright 2010-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2010-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See accompanying text file for licence details (MIT license).
 """
@@ -26,7 +26,7 @@ from __future__ import print_function
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.6")
+    print("v0.0.7")
     sys.exit(0)
 
 from galaxy_utils.sequence.fastq import fastqReader, fastqWriter

--- a/tools/fastq_filter_by_id/fastq_filter_by_id.py
+++ b/tools/fastq_filter_by_id/fastq_filter_by_id.py
@@ -45,7 +45,7 @@ except ValueError:
 
 # Read tabular file and record all specified identifiers
 ids = set()
-handle = open(tabular_file, "rU")
+handle = open(tabular_file)
 if len(columns) > 1:
     # General case of many columns
     for line in handle:
@@ -66,7 +66,7 @@ else:
 handle.close()
 
 # Write filtered FASTQ file based on IDs from tabular file
-reader = fastqReader(open(in_file, "rU"))
+reader = fastqReader(open(in_file))
 if out_positive_file != "-" and out_negative_file != "-":
     print("Generating two FASTQ files")
     positive_writer = fastqWriter(open(out_positive_file, "w"))

--- a/tools/fastq_filter_by_id/fastq_filter_by_id.xml
+++ b/tools/fastq_filter_by_id/fastq_filter_by_id.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_filter_by_id" name="Filter FASTQ by ID" version="0.0.6" hidden="true">
+<tool id="fastq_filter_by_id" name="Filter FASTQ by ID" version="0.0.7" hidden="true">
     <description>from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tools/predictnls/README.rst
+++ b/tools/predictnls/README.rst
@@ -70,6 +70,7 @@ v0.0.9  - Use ``<command detect_errors="aggressive">`` (internal change only).
         - Single quote command line arguments (internal change only).
         - Python 3 compatible print function.
         - Record version of the Python script.
+v0.0.10 - Fix file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/predictnls/predictnls.py
+++ b/tools/predictnls/predictnls.py
@@ -88,7 +88,7 @@ if not os.path.isfile(re_filename):
 
 def load_re(filename):
     """Parse the 5+ column tabular NLS motif file."""
-    handle = open(filename, "rU")
+    handle = open(filename)
     for line in handle:
         line = line.rstrip("\n")
         if not line:

--- a/tools/predictnls/predictnls.py
+++ b/tools/predictnls/predictnls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2011-2013 by Peter Cock, James Hutton Institute (formerly SCRI), UK
+# Copyright 2011-2023 by Peter Cock, James Hutton Institute (formerly SCRI), UK
 #
 # Licenced under the GPL (GNU General Public Licence) version 3.
 #
@@ -56,7 +56,7 @@ import re
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.9")
+    print("v0.0.10")
     sys.exit(0)
 
 if len(sys.argv) == 4:

--- a/tools/predictnls/predictnls.xml
+++ b/tools/predictnls/predictnls.xml
@@ -1,4 +1,4 @@
-<tool id="predictnls" name="PredictNLS" version="0.0.9">
+<tool id="predictnls" name="PredictNLS" version="0.0.10">
     <description>Find nuclear localization signals (NLSs) in protein sequences</description>
     <version_command>
 python $__tool_directory__/predictnls.py --version

--- a/tools/seq_filter_by_id/README.rst
+++ b/tools/seq_filter_by_id/README.rst
@@ -96,6 +96,7 @@ v0.2.7  - Python 3 compatible print function.
         - Use ``<command detect_errors="aggressive">`` (internal change only).
         - Single quote command line arguments (internal change only).
 v0.2.8  - Bumped Biopython dependency version for Python 3 fixes.
+v0.2.9  - Fixed file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/seq_filter_by_id/seq_filter_by_id.py
+++ b/tools/seq_filter_by_id/seq_filter_by_id.py
@@ -247,7 +247,7 @@ if options.id_list:
     print("Have %i unique identifiers from list" % len(ids))
 for tabular_file, columns in identifiers:
     file_ids = set()
-    handle = open(tabular_file, "rU")
+    handle = open(tabular_file)
     if len(columns) > 1:
         # General case of many columns
         for line in handle:

--- a/tools/seq_filter_by_id/seq_filter_by_id.py
+++ b/tools/seq_filter_by_id/seq_filter_by_id.py
@@ -21,7 +21,7 @@ Cock et al 2009. Biopython: freely available Python tools for computational
 molecular biology and bioinformatics. Bioinformatics 25(11) 1422-3.
 https://doi.org/10.1093/bioinformatics/btp163 pmid:19304878.
 
-This script is copyright 2010-2017 by Peter Cock, The James Hutton Institute
+This script is copyright 2010-2023 by Peter Cock, The James Hutton Institute
 (formerly the Scottish Crop Research Institute, SCRI), UK. All rights reserved.
 See accompanying text file for licence details (MIT license).
 
@@ -113,7 +113,7 @@ parser.add_option(
 options, args = parser.parse_args()
 
 if options.version:
-    print("v0.2.7")
+    print("v0.2.9")
     sys.exit(0)
 
 in_file = options.input

--- a/tools/seq_filter_by_id/seq_filter_by_id.xml
+++ b/tools/seq_filter_by_id/seq_filter_by_id.xml
@@ -1,4 +1,4 @@
-<tool id="seq_filter_by_id" name="Filter sequences by ID" version="0.2.8">
+<tool id="seq_filter_by_id" name="Filter sequences by ID" version="0.2.9">
     <description>from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.81">biopython</requirement>

--- a/tools/seq_primer_clip/README.rst
+++ b/tools/seq_primer_clip/README.rst
@@ -1,7 +1,7 @@
 Galaxy tool to primer clip (trim) FASTA, FASTQ or SFF reads
 ===========================================================
 
-This tool is copyright 2011-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2011-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See the licence text below (MIT licence).
 
@@ -74,6 +74,8 @@ v0.0.14 - Depends on Biopython 1.67 via legacy Tool Shed package or bioconda.
 v0.0.15 - Use ``<command detect_errors="aggressive">`` (internal change only).
         - Single quote command line arguments (internal change only)
 v0.0.16 - Python 3 compatible print function.
+v0.0.17 - Use Python 3 style dictionary iteration.
+v0.0.18 - Fix file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/seq_primer_clip/seq_primer_clip.py
+++ b/tools/seq_primer_clip/seq_primer_clip.py
@@ -201,7 +201,7 @@ def load_primers_as_re(primer_fasta, mm, rc=False):
     Read primer file and record all specified sequences.
     """
     primers = set()
-    in_handle = open(primer_fasta, "rU")
+    in_handle = open(primer_fasta)
     reader = fastaReader(in_handle)
     count = 0
     for record in reader:
@@ -293,7 +293,7 @@ if seq_format.lower() == "sff":
     writer.write_file(process(SffIterator(in_handle)))
     # End of SFF code
 elif seq_format.lower().startswith("fastq"):
-    in_handle = open(in_file, "rU")
+    in_handle = open(in_file)
     out_handle = open(out_file, "w")
     reader = fastqReader(in_handle)
     writer = fastqWriter(out_handle)
@@ -338,7 +338,7 @@ elif seq_format.lower().startswith("fastq"):
                 else:
                     short_neg += 1
 elif seq_format.lower() == "fasta":
-    in_handle = open(in_file, "rU")
+    in_handle = open(in_file)
     out_handle = open(out_file, "w")
     reader = fastaReader(in_handle)
     writer = fastaWriter(out_handle)

--- a/tools/seq_primer_clip/seq_primer_clip.py
+++ b/tools/seq_primer_clip/seq_primer_clip.py
@@ -22,7 +22,7 @@ This can also be used for stripping off (and optionally filtering on) barcodes.
 Note that only the trim/clip values in the SFF file are changed, not the flow
 information of the full read sequence.
 
-This script is copyright 2011-2013 by Peter Cock, The James Hutton Institute
+This script is copyright 2011-2023 by Peter Cock, The James Hutton Institute
 (formerly the Scottish Crop Research Institute, SCRI), UK. All rights reserved.
 See accompanying text file for licence details (MIT/BSD style).
 
@@ -34,7 +34,7 @@ import re
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.17")
+    print("v0.0.18")
     sys.exit(0)
 
 from galaxy_utils.sequence.fasta import fastaReader, fastaWriter

--- a/tools/seq_primer_clip/seq_primer_clip.xml
+++ b/tools/seq_primer_clip/seq_primer_clip.xml
@@ -1,4 +1,4 @@
-<tool id="seq_primer_clip" name="Primer clip sequences" version="0.0.16">
+<tool id="seq_primer_clip" name="Primer clip sequences" version="0.0.18">
     <description>Trim off 5' or 3' primers</description>
     <requirements>
         <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tools/seq_rename/README.rst
+++ b/tools/seq_rename/README.rst
@@ -1,7 +1,7 @@
 Galaxy tool to rename FASTA, QUAL, FASTQ or SFF sequences
 =========================================================
 
-This tool is copyright 2011-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2011-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See the licence text below.
 
@@ -85,6 +85,7 @@ v0.0.8  - Updated to point at Biopython 1.67 (latest version in Tool Shed).
 v0.0.9  - Use ``<command detect_errors="aggressive">`` (internal change only).
         - Single quote command line arguments (internal change only).
         - Python 3 compatible print function.
+v0.0.10 - Fix file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/seq_rename/seq_rename.py
+++ b/tools/seq_rename/seq_rename.py
@@ -17,7 +17,7 @@ Cock et al 2009. Biopython: freely available Python tools for computational
 molecular biology and bioinformatics. Bioinformatics 25(11) 1422-3.
 https://doi.org/10.1093/bioinformatics/btp163 pmid:19304878.
 
-This script is copyright 2011-2017 by Peter Cock, The James Hutton Institute UK.
+This script is copyright 2011-2023 by Peter Cock, The James Hutton Institute UK.
 All rights reserved. See accompanying text file for licence details (MIT
 license).
 """
@@ -27,7 +27,7 @@ from __future__ import print_function
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.9")
+    print("v0.0.10")
     sys.exit(0)
 
 # Parse Command Line

--- a/tools/seq_rename/seq_rename.py
+++ b/tools/seq_rename/seq_rename.py
@@ -67,7 +67,7 @@ def parse_ids(tabular_file, old_col, new_col):
 
     Internal white space in the new column is taken as desired output.
     """
-    handle = open(tabular_file, "rU")
+    handle = open(tabular_file)
     old_warn = False
     new_warn = False
     for line in handle:
@@ -144,13 +144,13 @@ else:
     ):
         from galaxy_utils.sequence.fasta import fastaReader, fastaWriter
 
-        reader = fastaReader(open(in_file, "rU"))
+        reader = fastaReader(open(in_file))
         writer = fastaWriter(open(out_file, "w"))
         marker = ">"
     elif seq_format.lower().startswith("fastq"):
         from galaxy_utils.sequence.fastq import fastqReader, fastqWriter
 
-        reader = fastqReader(open(in_file, "rU"))
+        reader = fastqReader(open(in_file))
         writer = fastqWriter(open(out_file, "w"))
         marker = "@"
     else:

--- a/tools/seq_rename/seq_rename.xml
+++ b/tools/seq_rename/seq_rename.xml
@@ -1,4 +1,4 @@
-<tool id="seq_rename" name="Rename sequences" version="0.0.9">
+<tool id="seq_rename" name="Rename sequences" version="0.0.10">
     <description>with ID mapping from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tools/seq_select_by_id/README.rst
+++ b/tools/seq_select_by_id/README.rst
@@ -1,7 +1,7 @@
 Galaxy tool to select FASTA, QUAL, FASTQ or SFF sequences by ID
 ===============================================================
 
-This tool is copyright 2011-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2011-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See the licence text below.
 
@@ -91,6 +91,7 @@ v0.0.12 - Python style changes (internal change only).
         - Python 3 compatible print function.
 v0.0.13 - Python 3 compatible exception handling.
 v0.0.14 - Script works on Python 2 and 3 (fixed output file mode).
+v0.0.15 - Fixed file open mode for Python 3.11 onwards.
 ======= ======================================================================
 
 

--- a/tools/seq_select_by_id/seq_select_by_id.py
+++ b/tools/seq_select_by_id/seq_select_by_id.py
@@ -16,7 +16,7 @@ Cock et al 2009. Biopython: freely available Python tools for computational
 molecular biology and bioinformatics. Bioinformatics 25(11) 1422-3.
 https://doi.org/10.1093/bioinformatics/btp163 pmid:19304878.
 
-This script is copyright 2011-2017 by Peter Cock, The James Hutton Institute UK.
+This script is copyright 2011-2023 by Peter Cock, The James Hutton Institute UK.
 All rights reserved. See accompanying text file for licence details (MIT
 license).
 """
@@ -26,7 +26,7 @@ from __future__ import print_function
 import sys
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.14")
+    print("v0.0.15")
     sys.exit(0)
 
 # Parse Command Line

--- a/tools/seq_select_by_id/seq_select_by_id.py
+++ b/tools/seq_select_by_id/seq_select_by_id.py
@@ -71,7 +71,7 @@ def parse_ids(tabular_file, col):
     non-trailing white space (only the first word will be used as
     the identifier).
     """
-    handle = open(tabular_file, "rU")
+    handle = open(tabular_file)
     warn = False
     for line in handle:
         if line.strip() and not line.startswith("#"):

--- a/tools/seq_select_by_id/seq_select_by_id.xml
+++ b/tools/seq_select_by_id/seq_select_by_id.xml
@@ -1,4 +1,4 @@
-<tool id="seq_select_by_id" name="Select sequences by ID" version="0.0.14">
+<tool id="seq_select_by_id" name="Select sequences by ID" version="0.0.15">
     <description>from a tabular file</description>
     <requirements>
         <requirement type="package" version="1.67">biopython</requirement>

--- a/tools/venn_list/README.rst
+++ b/tools/venn_list/README.rst
@@ -1,7 +1,7 @@
 Galaxy tool to draw a Venn Diagram with up to 3 sets
 ====================================================
 
-This tool is copyright 2011-2017 by Peter Cock, The James Hutton Institute
+This tool is copyright 2011-2023 by Peter Cock, The James Hutton Institute
 (formerly SCRI, Scottish Crop Research Institute), UK. All rights reserved.
 See the licence text below.
 
@@ -54,6 +54,7 @@ History
 ======= ======================================================================
 Version Changes
 ------- ----------------------------------------------------------------------
+v0.1.2  - Fixed file open mode for Python 3.11 onwards.
 v0.1.1  - Removed legacy ``tool_dependencies.xml`` file (the legacy Galaxy
           packages did not cover matplotlib_venn anyway).
 v0.1.0  - Now uses Python library matplotlib_venn to draw the diagram

--- a/tools/venn_list/venn_list.py
+++ b/tools/venn_list/venn_list.py
@@ -17,7 +17,7 @@ import sys
 from shutil import move
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.1.0")
+    print("v0.1.2")
     sys.exit(0)
 
 try:

--- a/tools/venn_list/venn_list.py
+++ b/tools/venn_list/venn_list.py
@@ -62,7 +62,7 @@ def load_ids(filename, filetype):
         # Use the Galaxy library not Biopython to cope with CS
         from galaxy_utils.sequence.fastq import fastqReader
 
-        handle = open(filename, "rU")
+        handle = open(filename)
         for record in fastqReader(handle):
             # The [1:] is because the fastaReader leaves the @ on the identifer.
             yield record.identifier.split()[0][1:]

--- a/tools/venn_list/venn_list.xml
+++ b/tools/venn_list/venn_list.xml
@@ -1,4 +1,4 @@
-<tool id="venn_list" name="Venn Diagram" version="0.1.1">
+<tool id="venn_list" name="Venn Diagram" version="0.1.2">
     <description>from lists</description>
     <requirements>
         <requirement type="package" version="1.1.3">galaxy_sequence_utils</requirement>


### PR DESCRIPTION
Hoping this will fix the following error. `planemo test` passes with this:

```
Traceback (most recent call last):
  File "/mnt/tools/shed_tools/toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/83a19df00eab/seq_filter_by_id/tools/seq_filter_by_id/seq_filter_by_id.py", line 250, in <module>
    handle = open(tabular_file, "rU")
             ^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid mode: 'rU'
```